### PR TITLE
Allow tests to be run using pre-downloaded data files with --datadir

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,20 @@
+import os
+
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--datadir",
+                     help="path to data files")
+
+def pytest_generate_tests(metafunc):
+    if 'base_url' in metafunc.fixturenames:
+        if metafunc.config.option.datadir:
+            base_url = ('file://'
+                        + os.path.abspath(metafunc.config.option.datadir)
+                        + os.sep)
+        else:
+            base_url = 'http://hgdownload.cse.ucsc.edu/goldenpath/hg19/database/'
+            # Mirror. Slightly faster and more stable, I believe -KT
+
+            base_url = 'http://kt.era.ee/distribute/pyintervaltree/'
+        metafunc.parametrize('base_url',[base_url])

--- a/tests/genomeintervaltree_test.py
+++ b/tests/genomeintervaltree_test.py
@@ -13,11 +13,9 @@ except ImportError: # Python 3?
 
 from intervaltree_bio import GenomeIntervalTree, UCSCTable
 
-def test_knownGene():
+def test_knownGene(base_url):
     # To speed up testing, we'll download the file and reuse the downloaded copy
-    knownGene_url = 'http://hgdownload.cse.ucsc.edu/goldenpath/hg19/database/knownGene.txt.gz'
-    # Mirror. Slightly faster and more stable, I believe:
-    knownGene_url = 'http://kt.era.ee/distribute/pyintervaltree/knownGene.txt.gz'
+    knownGene_url = base_url + 'knownGene.txt.gz'
 
     # To speed up testing, we'll download the file and reuse the downloaded copy
     knownGene_file, headers = urlretrieve(knownGene_url)
@@ -39,16 +37,14 @@ def test_knownGene():
     assert len(result) == 3
     assert result[0].data == result[1].data and result[0].data == result[2].data
     
-def test_ensGene():
+def test_ensGene(base_url):
     # Smoke-test we can at least read ensGene.
-    ensGene_url = 'http://hgdownload.cse.ucsc.edu/goldenpath/hg19/database/ensGene.txt.gz'
-    ensGene_url = 'http://kt.era.ee/distribute/pyintervaltree/ensGene.txt.gz'
+    ensGene_url = base_url + 'ensGene.txt.gz'
     ensGene = GenomeIntervalTree.from_table(url=ensGene_url, mode='cds', parser=UCSCTable.ENS_GENE)
     assert len(ensGene) == 204940
 
-def test_refGene():
+def test_refGene(base_url):
     # Smoke-test for refGene
-    refGene_url = 'http://hgdownload.cse.ucsc.edu/goldenpath/hg19/database/refGene.txt.gz'
-    refGene_url = 'http://kt.era.ee/distribute/pyintervaltree/refGene.txt.gz'
+    refGene_url = base_url + 'refGene.txt.gz'
     refGene = GenomeIntervalTree.from_table(url=refGene_url, mode='tx', parser=UCSCTable.REF_GENE)
     assert len(refGene) == 52350  # NB: Some time ago it was 50919, hence it seems the table data changes on UCSC and eventually the mirror and UCSC won't be the same.


### PR DESCRIPTION
For Debian, the package build process must not connect to the internet.
If data files are included with the package source, this patch allows
passing --datadir <path-to-folder-containing-required-data> to pytest
without attempting a download.