### PR TITLE
Update pytest setup.cfg entry

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 tag_build = 
 tag_svn_revision = false
 
-[pytest]
+[tool:pytest]
 addopts = --ignore=setup.py --ignore=build --ignore=dist --doctest-modules
 norecursedirs=*.egg
 


### PR DESCRIPTION
Address this warning (seen with pytest 3.x):

============================ pytest-warning summary ============================
WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.
================= 4 passed, 1 pytest-warnings in 83.34 seconds =================